### PR TITLE
registry-image in favor of deprecated docker-image resource

### DIFF
--- a/ci/tasks/run-tests-dynamic.yml
+++ b/ci/tasks/run-tests-dynamic.yml
@@ -2,7 +2,7 @@
 platform: linux
 
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
     repository: golang
 


### PR DESCRIPTION
our bosh bootloader (bbl) ci uses these tests.